### PR TITLE
New assSpecialChar syntax group

### DIFF
--- a/syntax/ass.vim
+++ b/syntax/ass.vim
@@ -15,9 +15,10 @@ syn match assDialog        "^Dialogue:\s*"   contained nextgroup=assDialogTimes
 syn match assDialogTimes   "\([^,]*,\)\{4}"  contained nextgroup=assDialogActor
 syn match assDialogActor   "[^,]*"           contained nextgroup=assDialogEffects
 syn match assDialogEffects ",\([^,]*,\)\{4}" contained nextgroup=assDialogText
-syn match assDialogText    ".*$"             contained contains=assTextComment,assTextSubCode
+syn match assDialogText    ".*$"             contained contains=assTextComment,assTextSubCode,assSpecialChar
 syn match assTextComment   "{[^}]*}"         contained
 syn match assTextSubCode   "{\\[^}]*}"       contained
+syn match assSpecialChar   "\\[nNh{}]"       contained contains=@NoSpell
 
 hi def link assSection         Function
 hi def link assSourceComment   Comment
@@ -32,5 +33,6 @@ hi def link assDialogEffects   Function
 hi def link assDialogText      Identifier
 hi def link assTextComment     Comment
 hi def link assTextSubCode     Comment
+hi def link assSpecialChar     Comment
 
 let b:current_syntax = "ass"


### PR DESCRIPTION
Highlight special characters described in [Aegisub Manual][1]. Exclude them
from spell-checking so Vim won't underline correct words after them.

 [1]: http://docs.aegisub.org/3.2/ASS_Tags/